### PR TITLE
Implement AI-assisted artifact generation

### DIFF
--- a/ops_translate/cli.py
+++ b/ops_translate/cli.py
@@ -289,13 +289,10 @@ def generate(
     mode = "template-based" if no_ai else "AI-assisted"
     console.print(f"[bold blue]Generating artifacts ({mode}):[/bold blue] profile={profile}")
 
-    from ops_translate.generate import ansible, kubevirt
+    from ops_translate.generate import generate_all
 
-    # Generate KubeVirt VM manifest
-    kubevirt.generate(workspace, profile, use_ai=not no_ai)
-
-    # Generate Ansible playbook and role
-    ansible.generate(workspace, profile, use_ai=not no_ai)
+    # Generate all artifacts
+    generate_all(workspace, profile, use_ai=not no_ai)
 
     console.print(f"[green]✓ KubeVirt manifest: output/kubevirt/vm.yaml[/green]")
     console.print(f"[green]✓ Ansible playbook: output/ansible/site.yml[/green]")

--- a/ops_translate/generate/__init__.py
+++ b/ops_translate/generate/__init__.py
@@ -1,0 +1,6 @@
+"""
+Artifact generation module.
+"""
+from ops_translate.generate.generator import generate_all
+
+__all__ = ['generate_all']

--- a/ops_translate/generate/generator.py
+++ b/ops_translate/generate/generator.py
@@ -1,0 +1,146 @@
+"""
+Unified artifact generation using LLM or templates.
+"""
+from pathlib import Path
+from ops_translate.workspace import Workspace
+from ops_translate.llm import get_provider
+from ops_translate.util.files import write_text, ensure_dir
+from rich.console import Console
+import yaml
+import re
+
+console = Console()
+
+# Get project root to find prompts
+PROJECT_ROOT = Path(__file__).parent.parent.parent
+
+
+def generate_all(workspace: Workspace, profile: str, use_ai: bool = False):
+    """
+    Generate all artifacts (KubeVirt + Ansible) using AI or templates.
+
+    Args:
+        workspace: Workspace instance
+        profile: Profile name (lab/prod)
+        use_ai: If True, use LLM. If False, use templates.
+    """
+    if use_ai:
+        generate_with_ai(workspace, profile)
+    else:
+        generate_with_templates(workspace, profile)
+
+
+def generate_with_ai(workspace: Workspace, profile: str):
+    """
+    Generate artifacts using LLM.
+
+    Reads intent/intent.yaml and calls LLM to generate all artifacts.
+    """
+    # Load config and initialize LLM
+    config = workspace.load_config()
+    llm = get_provider(config)
+
+    if not llm.is_available():
+        console.print("[yellow]Warning: LLM not available. Falling back to templates.[/yellow]")
+        generate_with_templates(workspace, profile)
+        return
+
+    # Load intent
+    intent_file = workspace.root / "intent/intent.yaml"
+    if not intent_file.exists():
+        console.print("[red]Error: intent/intent.yaml not found. Run 'intent extract' first.[/red]")
+        return
+
+    intent_yaml = intent_file.read_text()
+
+    # Load profile config
+    profile_config = config['profiles'][profile]
+
+    # Load prompt template
+    prompt_file = PROJECT_ROOT / "prompts/generate_artifacts.md"
+    prompt_template = prompt_file.read_text()
+
+    # Format profile config as YAML
+    profile_yaml = f"""profile_name: {profile}
+default_namespace: {profile_config['default_namespace']}
+default_network: {profile_config['default_network']}
+default_storage_class: {profile_config['default_storage_class']}"""
+
+    # Fill in prompt
+    prompt = prompt_template.replace("{intent_yaml}", intent_yaml)
+    prompt = prompt.replace("{profile_config}", profile_yaml)
+
+    console.print(f"[dim]Calling LLM to generate artifacts (this may take a moment)...[/dim]")
+
+    # Call LLM
+    try:
+        response = llm.generate(
+            prompt,
+            max_tokens=8192,  # Larger for multiple files
+            temperature=0.0
+        )
+
+        # Parse multi-file response
+        files = parse_multifile_response(response)
+
+        # Write each file
+        for file_path, content in files.items():
+            full_path = workspace.root / file_path
+            ensure_dir(full_path.parent)
+            write_text(full_path, content)
+            console.print(f"[dim]  Generated: {file_path}[/dim]")
+
+        if not files:
+            console.print("[yellow]Warning: No files extracted from LLM response. Falling back to templates.[/yellow]")
+            generate_with_templates(workspace, profile)
+
+    except Exception as e:
+        console.print(f"[red]Error calling LLM: {e}[/red]")
+        console.print("[yellow]Falling back to template-based generation[/yellow]")
+        generate_with_templates(workspace, profile)
+
+
+def parse_multifile_response(response: str) -> dict:
+    """
+    Parse LLM response with multiple files.
+
+    Expected format:
+    FILE: path/to/file.yaml
+    ---
+    content here
+    ---
+
+    FILE: path/to/another.yaml
+    ---
+    more content
+    ---
+
+    Returns:
+        dict: {file_path: content}
+    """
+    files = {}
+
+    # Split by FILE: markers
+    file_pattern = r'FILE:\s*([^\n]+)\n---\n(.*?)\n---'
+    matches = re.findall(file_pattern, response, re.DOTALL)
+
+    for file_path, content in matches:
+        file_path = file_path.strip()
+        content = content.strip()
+        files[file_path] = content
+
+    return files
+
+
+def generate_with_templates(workspace: Workspace, profile: str):
+    """
+    Generate artifacts using static templates (fallback).
+    """
+    from ops_translate.generate import ansible, kubevirt
+
+    config = workspace.load_config()
+    profile_config = config['profiles'][profile]
+
+    # Generate using template functions
+    kubevirt.generate(workspace, profile, use_ai=False)
+    ansible.generate(workspace, profile, use_ai=False)


### PR DESCRIPTION
## Overview

Implements AI-powered generation of KubeVirt and Ansible artifacts. When users run `generate --profile <name>` (without `--no-ai`), the tool now uses LLMs to create production-ready, context-aware artifacts based on the extracted intent.

## What Changed

### New Unified Generator
- `generate/generator.py` - Handles both AI and template modes
- Loads `intent/intent.yaml` and profile config
- Calls LLM with `prompts/generate_artifacts.md`
- Parses multi-file response format: `FILE: path\n---\ncontent\n---`
- Writes all generated files to workspace
- Graceful fallback to templates if LLM unavailable

### Updated CLI
- `generate` command now uses `generate_all()` function
- Default behavior: AI-assisted (requires API key)
- `--no-ai` flag: Template-based (no API calls)

## AI Generation Quality

The AI-generated artifacts are **dramatically better** than templates:

### KubeVirt Manifest

**Before (template):**
```yaml
metadata:
  name: example-vm
  namespace: virt-lab
  labels:
    app: example-vm
spec:
  domain:
    cpu:
      cores: 2
    resources:
      requests:
        memory: 4Gi
```

**After (AI):**
```yaml
metadata:
  name: "{{ vm_name }}"
  namespace: "{{ namespace | default('virt-lab') }}"
  labels:
    kubevirt.io/vm: "{{ vm_name }}"
    env: "{{ environment }}"
    managed-by: ops-translate
    owner: "{{ owner_email | replace('@', '-at-') }}"
  annotations:
    owner-email: "{{ owner_email }}"
    provisioned-date: "{{ ansible_date_time.iso8601 }}"
    cost-center: "{{ cost_center | default('') }}"
    workflow-name: "provision_vm_with_governance"
spec:
  domain:
    cpu:
      cores: {{ cpu_count }}
      sockets: 1
      threads: 1
    resources:
      requests:
        memory: "{{ memory_gb }}Gi"
        cpu: "{{ cpu_count }}"
      limits:
        memory: "{{ memory_gb }}Gi"
        cpu: "{{ cpu_count }}"
```

### Ansible Playbook

**Before (template):**
```yaml
- name: Provision KubeVirt VM
  hosts: localhost
  gather_facts: false
  roles:
    - provision_vm
```

**After (AI):**
```yaml
- name: Provision Virtual Machine on OpenShift Virtualization
  hosts: localhost
  gather_facts: true
  
  vars_prompt:
    - name: vm_name
      prompt: "Enter VM name"
    - name: environment
      prompt: "Enter environment (dev/prod)"
      default: "dev"
    # ... more prompts
  
  pre_tasks:
    - name: Display workflow information
      debug:
        msg:
          - "VM Name: {{ vm_name }}"
          - "Environment: {{ environment }}"
          # ... comprehensive info
  
  roles:
    - provision_vm
  
  post_tasks:
    - name: Display provisioning summary
      debug:
        msg:
          - "Next Steps:"
          - "  1. Start the VM: oc patch vm ..."
          - "  2. Check status: oc get vm ..."
```

### Ansible Tasks (200+ lines!)

The AI-generated `tasks/main.yml` includes:
- ✅ Comprehensive input validation with detailed error messages
- ✅ Environment-based profile selection
- ✅ Production approval workflow (blocks deployment)
- ✅ Pre-flight checks (VM already exists?)
- ✅ PVC creation and wait-for-bound
- ✅ VM creation with full spec
- ✅ Metadata tagging for governance
- ✅ Output variables (vm_id, status)
- ✅ Check mode support

## Files Generated by AI

When run with real API key:
1. `output/kubevirt/vm.yaml` - Parameterized KubeVirt manifest
2. `output/ansible/site.yml` - Interactive playbook with prompts
3. `output/ansible/roles/provision_vm/tasks/main.yml` - 200+ lines of tasks
4. `output/ansible/roles/provision_vm/defaults/main.yml` - Comprehensive defaults
5. `output/ansible/roles/provision_vm/vars/main.yml` - Additional variables
6. `output/ansible/ansible.cfg` - Ansible configuration
7. `output/ansible/inventory/hosts` - Inventory file

## Testing

Tested end-to-end with Anthropic Claude:
```bash
export OPS_TRANSLATE_LLM_API_KEY=$ANTHROPIC_API_KEY
ops-translate init demo && cd demo
ops-translate import --source powercli --file ../examples/powercli/provision-vm.ps1
ops-translate import --source vrealize --file ../examples/vrealize/provision.workflow.xml
ops-translate intent extract
ops-translate intent merge
ops-translate generate --profile lab  # AI-assisted! 🚀
```

Result: Production-ready Ansible playbooks and KubeVirt manifests that understand the actual workflow intent.

## Backward Compatibility

- `--no-ai` flag still works (uses templates)
- Automatic fallback if LLM unavailable
- No breaking changes to existing workflows

## What's Next

This completes the core AI-powered migration workflow from SPEC.md! 🎉

Remaining enhancements:
- Schema validation with jsonschema
- Enhanced conflict detection in merge
- README generation (currently not in LLM output)