### PR TITLE
Add JSON schema validation to intent extraction and merging

### DIFF
--- a/ops_translate/intent/extract.py
+++ b/ops_translate/intent/extract.py
@@ -44,6 +44,16 @@ def extract_all(workspace: Workspace):
             output_file = workspace.root / "intent" / f"{ps_file.stem}.intent.yaml"
             output_file.write_text(intent_yaml)
 
+            # Validate extracted intent
+            from ops_translate.intent.validate import validate_intent
+            is_valid, errors = validate_intent(output_file)
+            if not is_valid:
+                console.print(f"[yellow]  Warning: Intent validation failed for {output_file.name}:[/yellow]")
+                for error in errors:
+                    console.print(f"[yellow]    {error}[/yellow]")
+            else:
+                console.print(f"[dim]  ✓ Schema validation passed[/dim]")
+
             assumptions.append(f"## {ps_file.name}\n")
             assumptions.extend([f"- {a}" for a in file_assumptions])
             assumptions.append("")
@@ -58,6 +68,16 @@ def extract_all(workspace: Workspace):
 
             output_file = workspace.root / "intent" / f"{xml_file.stem}.intent.yaml"
             output_file.write_text(intent_yaml)
+
+            # Validate extracted intent
+            from ops_translate.intent.validate import validate_intent
+            is_valid, errors = validate_intent(output_file)
+            if not is_valid:
+                console.print(f"[yellow]  Warning: Intent validation failed for {output_file.name}:[/yellow]")
+                for error in errors:
+                    console.print(f"[yellow]    {error}[/yellow]")
+            else:
+                console.print(f"[dim]  ✓ Schema validation passed[/dim]")
 
             assumptions.append(f"## {xml_file.name}\n")
             assumptions.extend([f"- {a}" for a in file_assumptions])

--- a/ops_translate/intent/merge.py
+++ b/ops_translate/intent/merge.py
@@ -40,6 +40,20 @@ def merge_intents(workspace: Workspace) -> bool:
     with open(output_file, 'w') as f:
         yaml.dump(merged_intent, f, default_flow_style=False, sort_keys=False)
 
+    # Validate merged intent against schema
+    from ops_translate.intent.validate import validate_intent
+    from rich.console import Console
+    console = Console()
+
+    is_valid, errors = validate_intent(output_file)
+    if not is_valid:
+        console.print(f"[yellow]Warning: Merged intent validation failed:[/yellow]")
+        for error in errors:
+            console.print(f"[yellow]  {error}[/yellow]")
+        console.print(f"[yellow]Merged intent written but may have schema issues.[/yellow]")
+    else:
+        console.print(f"[dim]✓ Merged intent schema validation passed[/dim]")
+
     # Check for conflicts (simplified for now)
     conflicts = detect_conflicts(intent_files)
 

--- a/ops_translate/intent/validate.py
+++ b/ops_translate/intent/validate.py
@@ -4,37 +4,97 @@ Intent and artifact validation.
 from pathlib import Path
 import yaml
 import json
+from jsonschema import validate, ValidationError, Draft7Validator
+from jsonschema.exceptions import SchemaError
+
+# Get project root to find schema
+PROJECT_ROOT = Path(__file__).parent.parent.parent
 
 
 def validate_intent(intent_file: Path) -> tuple[bool, list]:
     """
-    Validate intent YAML against schema.
+    Validate intent YAML against schema using jsonschema.
 
     Returns:
         tuple: (is_valid, error_messages)
     """
     try:
+        # Load intent YAML
         intent = yaml.safe_load(intent_file.read_text())
 
-        errors = []
+        # Load schema
+        schema_file = PROJECT_ROOT / "schema/intent.schema.json"
+        if not schema_file.exists():
+            return (False, [f"Schema file not found: {schema_file}"])
 
-        # Basic schema validation
-        if 'schema_version' not in intent:
-            errors.append("Missing required field: schema_version")
+        schema = json.loads(schema_file.read_text())
 
-        if 'intent' not in intent:
-            errors.append("Missing required field: intent")
-        else:
-            intent_section = intent['intent']
-            if 'workflow_name' not in intent_section:
-                errors.append("Missing required field: intent.workflow_name")
-            if 'workload_type' not in intent_section:
-                errors.append("Missing required field: intent.workload_type")
-
-        return (len(errors) == 0, errors)
+        # Validate against schema
+        try:
+            validate(instance=intent, schema=schema)
+            return (True, [])
+        except ValidationError as e:
+            # Format validation error into helpful message
+            errors = format_validation_error(e)
+            return (False, errors)
+        except SchemaError as e:
+            return (False, [f"Invalid schema: {e}"])
 
     except yaml.YAMLError as e:
         return (False, [f"YAML parse error: {e}"])
+    except Exception as e:
+        return (False, [f"Validation error: {e}"])
+
+
+def format_validation_error(error: ValidationError) -> list:
+    """
+    Format jsonschema ValidationError into user-friendly messages.
+
+    Args:
+        error: ValidationError from jsonschema
+
+    Returns:
+        list: List of formatted error messages
+    """
+    errors = []
+
+    # Build the path to the problematic field
+    path = ".".join(str(p) for p in error.path) if error.path else "root"
+
+    # Main error message
+    main_error = f"Validation error at '{path}': {error.message}"
+    errors.append(main_error)
+
+    # Add context about what was expected
+    if error.validator == 'required':
+        missing_props = error.message.split("'")[1::2]  # Extract property names
+        errors.append(f"  Required properties missing: {', '.join(missing_props)}")
+
+    elif error.validator == 'type':
+        errors.append(f"  Expected type: {error.validator_value}")
+        errors.append(f"  Got: {type(error.instance).__name__}")
+
+    elif error.validator == 'enum':
+        errors.append(f"  Allowed values: {error.validator_value}")
+        errors.append(f"  Got: {error.instance}")
+
+    elif error.validator == 'pattern':
+        errors.append(f"  Expected pattern: {error.validator_value}")
+        errors.append(f"  Got: {error.instance}")
+
+    elif error.validator == 'minimum' or error.validator == 'maximum':
+        errors.append(f"  Constraint: {error.validator} = {error.validator_value}")
+        errors.append(f"  Got: {error.instance}")
+
+    # Add suggestion for common errors
+    if 'schema_version' in str(error.path):
+        errors.append("  Hint: schema_version must be the integer 1")
+    elif 'workflow_name' in str(error.path):
+        errors.append("  Hint: workflow_name must be snake_case (lowercase with underscores)")
+    elif 'workload_type' in str(error.path):
+        errors.append("  Hint: workload_type must be one of: virtual_machine, container, baremetal, other")
+
+    return errors
 
 
 def validate_artifacts(workspace) -> tuple[bool, list]:


### PR DESCRIPTION
## Summary
- Implements comprehensive JSON schema validation for intent files using jsonschema library
- Validates extracted intents automatically during `intent extract` command
- Validates merged intent during `intent merge` command
- Provides detailed, user-friendly validation error messages with field paths and hints

## Implementation Details
- Updated `intent/validate.py` to use jsonschema Draft 7 validator
- Added `format_validation_error` helper function for clear error messages
- Integrated validation into extraction workflow (PowerCLI and vRealize)
- Integrated validation into merge workflow
- Validation warns users of schema issues while allowing workflow to continue

## Testing
- Tested with real Anthropic API - correctly identifies schema mismatches
- Tested with mock provider - validation works without API calls
- Validation provides actionable error messages with expected vs actual types

## Example Output
```
Warning: Intent validation failed for provision-vm.intent.yaml:
  Validation error at 'intent.profiles.storage_else': 'storage-standard' is not of type 'object'
    Expected type: object
    Got: str
```