### PR TITLE
Fix mypy type annotation errors in classifiers

### DIFF
--- a/ops_translate/intent/classifiers/approval.py
+++ b/ops_translate/intent/classifiers/approval.py
@@ -120,7 +120,7 @@ class ApprovalClassifier(BaseClassifier):
         Returns:
             List of classified approval components
         """
-        components = []
+        components: list[ClassifiedComponent] = []
 
         governance = intent.get("governance", {})
         approval_config = governance.get("approval")

--- a/ops_translate/intent/classifiers/orchestration.py
+++ b/ops_translate/intent/classifiers/orchestration.py
@@ -118,7 +118,7 @@ class OrchestrationClassifier(BaseClassifier):
         Returns:
             List of classified orchestration components
         """
-        components = []
+        components: list[ClassifiedComponent] = []
 
         if not self._has_orchestration_patterns(intent):
             return components

--- a/ops_translate/intent/classifiers/vro_plugins.py
+++ b/ops_translate/intent/classifiers/vro_plugins.py
@@ -121,7 +121,7 @@ class Vro_pluginsClassifier(BaseClassifier):
         Returns:
             List of classified integration components
         """
-        components = []
+        components: list[ClassifiedComponent] = []
 
         if not self._has_plugin_patterns(intent):
             return components


### PR DESCRIPTION
Fixes mypy type annotation errors that were flagged in CI after PR #25 was merged.

## Changes

Adds explicit type annotations to `components` variables in three classifier modules:
- `ops_translate/intent/classifiers/vro_plugins.py`
- `ops_translate/intent/classifiers/orchestration.py`
- `ops_translate/intent/classifiers/approval.py`

Changes `components = []` to `components: list[ClassifiedComponent] = []` to satisfy mypy's type checker.

## Testing

Passes `mypy ops_translate/` check.