### PR TITLE
Fix mypy type errors

### DIFF
--- a/ops_translate/intent/interview.py
+++ b/ops_translate/intent/interview.py
@@ -373,7 +373,7 @@ def apply_answers(
     answers = answers_data.get("answers", {})
 
     # Derive decisions using deterministic rules
-    decisions = {
+    decisions: dict[str, Any] = {
         "schema_version": 1,
         "derived_at": datetime.utcnow().isoformat() + "Z",
         "decisions": {},

--- a/ops_translate/summarize/vrealize.py
+++ b/ops_translate/summarize/vrealize.py
@@ -20,10 +20,15 @@ def summarize(xml_file: Path) -> str:
     except ElementTree.ParseError:
         return "**Error:** Unable to parse XML"
 
+    if root is None:
+        return "**Error:** Empty XML document"
+
     summary = []
 
     # Extract workflow display name
-    display_name = root.findtext(".//display-name") or root.findtext(".//displayName")
+    display_name = root.findtext(".//display-name")
+    if not display_name:
+        display_name = root.findtext(".//displayName")
     if display_name:
         summary.append(f"**Workflow:** {display_name}")
 


### PR DESCRIPTION
## Summary
- Fix indexed assignment error in interview.py by adding explicit type annotation
- Fix union-attr errors in vrealize.py by adding None check for XML root element
- Refactor display_name lookup to satisfy type checker

## Test plan
- [x] Run `mypy ops_translate/` to verify errors are resolved
- [x] Verify no ruff linting errors
- [x] Code changes are minimal and focused on type safety